### PR TITLE
Replace pyqtree with fastquadtree.pyqtree

### DIFF
--- a/legent/server/rect_placer.py
+++ b/legent/server/rect_placer.py
@@ -1,5 +1,5 @@
 from typing import Tuple
-from pyqtree import Index
+from fastquadtree.pyqtree import Index
 
 
 class RectPlacer:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     keywords=['nlp', 'embodied', 'ai'],
     python_requires=">=3.6.0",
     install_requires=[
-        "pyqtree", "flask", "huggingface_hub", "colorama", "cloudpickle", "grpcio==1.64.0", "numpy>=1.14.1", "Pillow>=4.2.1", "protobuf==3.20.3", "pyyaml>=3.1.0", "filelock>=3.4.0", "scikit-image", "tqdm", "openai==1.10.0",
+        "fastquadtree>=1.1.2,<2.0.0", "flask", "huggingface_hub", "colorama", "cloudpickle", "grpcio==1.64.0", "numpy>=1.14.1", "Pillow>=4.2.1", "protobuf==3.20.3", "pyyaml>=3.1.0", "filelock>=3.4.0", "scikit-image", "tqdm", "openai==1.10.0",
         "paramiko", "sshtunnel",
         "shapely==2.0.3", "attrs==23.2.0", "pandas==2.2.1", "matplotlib==3.8.3", # for scene generation
         "objaverse", "pyglet==1.5.28", "trimesh", # for objaverse


### PR DESCRIPTION
`fastquadtree` matches `pyqtree`’s interface but runs much faster and is more up to date. Prebuilt wheels are available on Windows, macOS, and Linux.

[Full fastquadtree documentation](https://elan456.github.io/fastquadtree/)

## Changes
- Replaced `pyqtree` with `fastquadtree` in the `setup.py`
- Replaced `import pyqtree` with `import fastquadtree.pyqtree as pyqtree` in `legent/server/rect_placer.py`

## Testing
I ran the demo in `docs\en\documentation\getting_started\play.md` without any crashes or noticeable weird behavior. 